### PR TITLE
Allow autocompletion to work for namespaced models.

### DIFF
--- a/lib/formtastic/inputs/token_input.rb
+++ b/lib/formtastic/inputs/token_input.rb
@@ -15,7 +15,7 @@ module Formtastic
          :required          => nil,
          :autofocus         => nil,
          :class             => 'token-input',
-         'data-model-name' => reflection.klass.model_name.singular
+         'data-model-name' => reflection.klass.model_name.underscore
         }).tap do |html_options|
           if record.present?
             html_options["data-pre"] = prepopulated_value.to_json


### PR DESCRIPTION
At the moment, when trying to setup the "autocomplete" functionality with a model that is under a package, the routing breaks.

Take the following model as an example:
"OleCore::Distributor"

This model, on [this line](https://github.com/vigetlabs/active_admin_associations/blob/master/lib/formtastic/inputs/token_input.rb#L18), is converted to the following path:

_ole_core_distributor_

Which is then received by the autocomplete processor on [this line](https://github.com/vigetlabs/active_admin_associations/blob/master/app/controllers/autocomplete_controller.rb#L17), which converts the path to:

_OleCoreDistributor_

Which, obviously, causes a ModelNotFound error to be thrown from rails.

The problem here is that when using a package name, the package cannot be converted to underscores, it has to be converted to slashes. By replacing the line on the first link (see my commit), the reflection generated is the following:

_ole_core/distributor_

Which works as long as you use the following configuration option in application.rb

```
config.aa_associations.autocomplete_models = %w(ole_core/distributor)
```

By using the right function, underscore, we allow autocompletion to work with any number of packages for any models!
