### PR TITLE
Update activeadmin dependency

### DIFF
--- a/activeadmin_associations.gemspec
+++ b/activeadmin_associations.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.extra_rdoc_files = ["README.md", "MIT_LICENSE.txt"]
 
-  s.add_dependency 'activeadmin', '1.0.0.pre'
+  s.add_dependency 'activeadmin', '~> 1.0.0.pre1'
   s.add_dependency 'rails', '~> 4.0'
 
   s.add_development_dependency 'rspec-rails', '~> 2.14.1'


### PR DESCRIPTION
activeadmin just released 1.0.0.pre1 version, so I had to update the dependency.
